### PR TITLE
Fix Google model typing in analyze-edit-intent API

### DIFF
--- a/app/api/analyze-edit-intent/route.ts
+++ b/app/api/analyze-edit-intent/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createGroq } from '@ai-sdk/groq';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
-import { createGoogleGenerativeAI } from '@ai-sdk/google';
-import { generateObject } from 'ai';
+import { google } from '@ai-sdk/google';
+import { generateObject, type LanguageModel } from 'ai';
 import { z } from 'zod';
 import type { FileManifest } from '@/types/file-manifest';
 
@@ -94,7 +94,7 @@ export async function POST(request: NextRequest) {
     console.log('[analyze-edit-intent] File summary preview:', fileSummary.split('\n').slice(0, 5).join('\n'));
     
     // Select the appropriate AI model based on the request
-    let aiModel;
+    let aiModel: LanguageModel;
     if (model.startsWith('anthropic/')) {
       aiModel = anthropic(model.replace('anthropic/', ''));
     } else if (model.startsWith('openai/')) {
@@ -104,7 +104,7 @@ export async function POST(request: NextRequest) {
         aiModel = openai(model.replace('openai/', ''));
       }
     } else if (model.startsWith('google/')) {
-      aiModel = createGoogleGenerativeAI(model.replace('google/', ''));
+      aiModel = google(model.replace('google/', '')) as LanguageModel;
     } else {
       // Default to groq if model format is unclear
       aiModel = groq(model);


### PR DESCRIPTION
## Summary
- use the `google` AI provider and set `aiModel` to `LanguageModel` in analyze-edit-intent route
- ensure Google model selection returns a `LanguageModel` compatible with `generateObject`
- cast dynamic Google model lookups to `LanguageModel` for type safety

## Testing
- `npm run test:all` *(fails: Cannot find module '/workspace/open-lovable/tests/e2b-integration.test.js')*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'missingImports' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689d88c9b94883248c16f1c92aa84d7c