### PR TITLE
Fix Google model typing and guard file cache access

### DIFF
--- a/app/api/analyze-edit-intent/route.ts
+++ b/app/api/analyze-edit-intent/route.ts
@@ -2,10 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createGroq } from '@ai-sdk/groq';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
-import { createGoogleGenerativeAI } from '@ai-sdk/google';
-import { generateObject } from 'ai';
+import { google } from '@ai-sdk/google';
+import { generateObject, type LanguageModel } from 'ai';
 import { z } from 'zod';
-import type { FileManifest } from '@/types/file-manifest';
 
 const groq = createGroq({
   apiKey: process.env.GROQ_API_KEY,
@@ -94,7 +93,7 @@ export async function POST(request: NextRequest) {
     console.log('[analyze-edit-intent] File summary preview:', fileSummary.split('\n').slice(0, 5).join('\n'));
     
     // Select the appropriate AI model based on the request
-    let aiModel;
+    let aiModel: LanguageModel;
     if (model.startsWith('anthropic/')) {
       aiModel = anthropic(model.replace('anthropic/', ''));
     } else if (model.startsWith('openai/')) {
@@ -104,7 +103,7 @@ export async function POST(request: NextRequest) {
         aiModel = openai(model.replace('openai/', ''));
       }
     } else if (model.startsWith('google/')) {
-      aiModel = createGoogleGenerativeAI(model.replace('google/', ''));
+      aiModel = google(model.replace('google/', ''));
     } else {
       // Default to groq if model format is unclear
       aiModel = groq(model);

--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -165,12 +165,13 @@ export async function POST(request: NextRequest) {
           console.log('[generate-ai-code-stream] Has fileCache:', !!global.sandboxState?.fileCache);
           console.log('[generate-ai-code-stream] Has manifest:', !!global.sandboxState?.fileCache?.manifest);
           
-          const manifest: FileManifest | undefined = global.sandboxState?.fileCache?.manifest;
-          
-          if (manifest) {
+          const fileCache = global.sandboxState.fileCache;
+          const manifest: FileManifest | undefined = fileCache?.manifest;
+
+          if (fileCache && manifest) {
             await sendProgress({ type: 'status', message: '🔍 Creating search plan...' });
-            
-            const fileContents = global.sandboxState.fileCache.files;
+
+            const fileContents = fileCache.files;
             console.log('[generate-ai-code-stream] Files available for search:', Object.keys(fileContents).length);
             
             // STEP 1: Get search plan from AI


### PR DESCRIPTION
## Summary
- use the `google` AI provider and set `aiModel` to `LanguageModel` in analyze-edit-intent route
- remove unused FileManifest import
- guard against `null` `global.sandboxState.fileCache` before accessing files in generate-ai-code-stream route

## Testing
- `npm run test:all` *(fails: Cannot find module '/workspace/open-lovable/tests/e2b-integration.test.js')*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'missingImports' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689d88c9b94883248c16f1c92aa84d7c