### PR TITLE
Fix Google model typing and clean unused variables

### DIFF
--- a/app/api/analyze-edit-intent/route.ts
+++ b/app/api/analyze-edit-intent/route.ts
@@ -2,10 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createGroq } from '@ai-sdk/groq';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
-import { createGoogleGenerativeAI } from '@ai-sdk/google';
-import { generateObject } from 'ai';
+import { google } from '@ai-sdk/google';
+import { generateObject, type LanguageModel } from 'ai';
 import { z } from 'zod';
-import type { FileManifest } from '@/types/file-manifest';
 
 const groq = createGroq({
   apiKey: process.env.GROQ_API_KEY,
@@ -66,15 +65,14 @@ export async function POST(request: NextRequest) {
     
     // Create a summary of available files for the AI
     const validFiles = Object.entries(manifest.files as Record<string, any>)
-      .filter(([path, info]) => {
+      .filter(([path]) => {
         // Filter out invalid paths
         return path.includes('.') && !path.match(/\/\d+$/);
       });
-    
+
     const fileSummary = validFiles
       .map(([path, info]: [string, any]) => {
         const componentName = info.componentInfo?.name || path.split('/').pop();
-        const hasImports = info.imports?.length > 0;
         const childComponents = info.componentInfo?.childComponents?.join(', ') || 'none';
         return `- ${path} (${componentName}, renders: ${childComponents})`;
       })
@@ -94,7 +92,7 @@ export async function POST(request: NextRequest) {
     console.log('[analyze-edit-intent] File summary preview:', fileSummary.split('\n').slice(0, 5).join('\n'));
     
     // Select the appropriate AI model based on the request
-    let aiModel;
+    let aiModel: LanguageModel;
     if (model.startsWith('anthropic/')) {
       aiModel = anthropic(model.replace('anthropic/', ''));
     } else if (model.startsWith('openai/')) {
@@ -104,7 +102,8 @@ export async function POST(request: NextRequest) {
         aiModel = openai(model.replace('openai/', ''));
       }
     } else if (model.startsWith('google/')) {
-      aiModel = createGoogleGenerativeAI(model.replace('google/', ''));
+      // Cast to LanguageModel to satisfy ai-sdk typing
+      aiModel = google(model.replace('google/', '')) as LanguageModel;
     } else {
       // Default to groq if model format is unclear
       aiModel = groq(model);

--- a/app/api/apply-ai-code-stream/route.ts
+++ b/app/api/apply-ai-code-stream/route.ts
@@ -463,7 +463,7 @@ export async function POST(request: NextRequest) {
                       if (data.type === 'success' && data.installedPackages) {
                         results.packagesInstalled = data.installedPackages;
                       }
-                    } catch (e) {
+                    } catch {
                       // Ignore parse errors
                     }
                   }

--- a/app/api/apply-ai-code/route.ts
+++ b/app/api/apply-ai-code/route.ts
@@ -491,7 +491,7 @@ with open(file_path, 'w') as f:
 print(f"Auto-generated: {file_path}")
           `);
           results.filesCreated.push('src/index.css (with Tailwind)');
-        } catch (error) {
+        } catch {
           results.errors.push('Failed to create index.css with Tailwind');
         }
       }

--- a/app/api/create-zip/route.ts
+++ b/app/api/create-zip/route.ts
@@ -1,10 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 
 declare global {
   var activeSandbox: any;
 }
 
-export async function POST(request: NextRequest) {
+export async function POST() {
   try {
     if (!global.activeSandbox) {
       return NextResponse.json({ 
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
     console.log('[create-zip] Creating project zip...');
     
     // Create zip file in sandbox
-    const result = await global.activeSandbox.runCode(`
+    await global.activeSandbox.runCode(`
 import zipfile
 import os
 import json

--- a/app/api/detect-and-install-packages/route.ts
+++ b/app/api/detect-and-install-packages/route.ts
@@ -65,7 +65,6 @@ export async function POST(request: NextRequest) {
       if (builtins.includes(imp)) return false;
       
       // Extract package name (handle scoped packages and subpaths)
-      const parts = imp.split('/');
       if (imp.startsWith('@')) {
         // Scoped package like @vitejs/plugin-react
         return true;

--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -165,12 +165,13 @@ export async function POST(request: NextRequest) {
           console.log('[generate-ai-code-stream] Has fileCache:', !!global.sandboxState?.fileCache);
           console.log('[generate-ai-code-stream] Has manifest:', !!global.sandboxState?.fileCache?.manifest);
           
-          const manifest: FileManifest | undefined = global.sandboxState?.fileCache?.manifest;
-          
-          if (manifest) {
+          const fileCache = global.sandboxState?.fileCache;
+          const manifest: FileManifest | undefined = fileCache?.manifest;
+
+          if (fileCache && manifest) {
             await sendProgress({ type: 'status', message: '🔍 Creating search plan...' });
-            
-            const fileContents = global.sandboxState.fileCache.files;
+
+            const fileContents = fileCache.files;
             console.log('[generate-ai-code-stream] Files available for search:', Object.keys(fileContents).length);
             
             // STEP 1: Get search plan from AI
@@ -221,8 +222,7 @@ export async function POST(request: NextRequest) {
                     
                     // Create surgical edit context with exact location
                     const normalizedPath = target.filePath.replace('/home/user/app/', '');
-                    const fileContent = fileContents[normalizedPath]?.content || '';
-                    
+
                     // Build enhanced context with search results
                     enhancedSystemPrompt = `
 ${formatSearchResultsForAI(searchExecution.results)}


### PR DESCRIPTION
## Summary
- use the `google` AI provider and set `aiModel` to `LanguageModel` in analyze-edit-intent route
- guard `global.sandboxState.fileCache` in generate-ai-code-stream to avoid null access
- remove unused variables across API routes to reduce TypeScript warnings

## Testing
- `npm run test:all` *(fails: Cannot find module '/workspace/open-lovable/tests/e2b-integration.test.js')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'missingImports' does not exist on type ...)*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*


------
https://chatgpt.com/codex/tasks/task_e_689d88c9b94883248c16f1c92aa84d7c