### PR TITLE
Fix Google model typing and guard sandbox file cache

### DIFF
--- a/app/api/analyze-edit-intent/route.ts
+++ b/app/api/analyze-edit-intent/route.ts
@@ -2,10 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createGroq } from '@ai-sdk/groq';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
-import { createGoogleGenerativeAI } from '@ai-sdk/google';
-import { generateObject } from 'ai';
+import { google } from '@ai-sdk/google';
+import { generateObject, type LanguageModel } from 'ai';
 import { z } from 'zod';
-import type { FileManifest } from '@/types/file-manifest';
 
 const groq = createGroq({
   apiKey: process.env.GROQ_API_KEY,
@@ -66,15 +65,14 @@ export async function POST(request: NextRequest) {
     
     // Create a summary of available files for the AI
     const validFiles = Object.entries(manifest.files as Record<string, any>)
-      .filter(([path, info]) => {
+      .filter(([path]) => {
         // Filter out invalid paths
         return path.includes('.') && !path.match(/\/\d+$/);
       });
-    
+
     const fileSummary = validFiles
       .map(([path, info]: [string, any]) => {
         const componentName = info.componentInfo?.name || path.split('/').pop();
-        const hasImports = info.imports?.length > 0;
         const childComponents = info.componentInfo?.childComponents?.join(', ') || 'none';
         return `- ${path} (${componentName}, renders: ${childComponents})`;
       })
@@ -94,7 +92,7 @@ export async function POST(request: NextRequest) {
     console.log('[analyze-edit-intent] File summary preview:', fileSummary.split('\n').slice(0, 5).join('\n'));
     
     // Select the appropriate AI model based on the request
-    let aiModel;
+    let aiModel: LanguageModel;
     if (model.startsWith('anthropic/')) {
       aiModel = anthropic(model.replace('anthropic/', ''));
     } else if (model.startsWith('openai/')) {
@@ -104,7 +102,8 @@ export async function POST(request: NextRequest) {
         aiModel = openai(model.replace('openai/', ''));
       }
     } else if (model.startsWith('google/')) {
-      aiModel = createGoogleGenerativeAI(model.replace('google/', ''));
+      // Cast to LanguageModel to satisfy ai-sdk typing
+      aiModel = google(model.replace('google/', '')) as LanguageModel;
     } else {
       // Default to groq if model format is unclear
       aiModel = groq(model);

--- a/app/api/apply-ai-code-stream/route.ts
+++ b/app/api/apply-ai-code-stream/route.ts
@@ -463,7 +463,7 @@ export async function POST(request: NextRequest) {
                       if (data.type === 'success' && data.installedPackages) {
                         results.packagesInstalled = data.installedPackages;
                       }
-                    } catch (e) {
+                    } catch {
                       // Ignore parse errors
                     }
                   }
@@ -549,8 +549,9 @@ print(f"File written: ${fullPath}")
             `);
             
             // Update file cache
-            if (global.sandboxState?.fileCache) {
-              global.sandboxState.fileCache.files[normalizedPath] = {
+            const cache = global.sandboxState?.fileCache;
+            if (cache) {
+              cache.files[normalizedPath] = {
                 content: fileContent,
                 lastModified: Date.now()
               };

--- a/app/api/apply-ai-code/route.ts
+++ b/app/api/apply-ai-code/route.ts
@@ -344,8 +344,9 @@ export async function POST(request: NextRequest) {
           console.log(`[apply-ai-code] Successfully wrote file: ${fullPath}`);
           
           // Update file cache
-          if (global.sandboxState?.fileCache) {
-            global.sandboxState.fileCache.files[normalizedPath] = {
+          const cache = global.sandboxState?.fileCache;
+          if (cache) {
+            cache.files[normalizedPath] = {
               content: fileContent,
               lastModified: Date.now()
             };
@@ -491,7 +492,7 @@ with open(file_path, 'w') as f:
 print(f"Auto-generated: {file_path}")
           `);
           results.filesCreated.push('src/index.css (with Tailwind)');
-        } catch (error) {
+        } catch {
           results.errors.push('Failed to create index.css with Tailwind');
         }
       }

--- a/app/api/create-zip/route.ts
+++ b/app/api/create-zip/route.ts
@@ -1,10 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 
 declare global {
   var activeSandbox: any;
 }
 
-export async function POST(request: NextRequest) {
+export async function POST() {
   try {
     if (!global.activeSandbox) {
       return NextResponse.json({ 
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
     console.log('[create-zip] Creating project zip...');
     
     // Create zip file in sandbox
-    const result = await global.activeSandbox.runCode(`
+    await global.activeSandbox.runCode(`
 import zipfile
 import os
 import json

--- a/app/api/detect-and-install-packages/route.ts
+++ b/app/api/detect-and-install-packages/route.ts
@@ -65,7 +65,6 @@ export async function POST(request: NextRequest) {
       if (builtins.includes(imp)) return false;
       
       // Extract package name (handle scoped packages and subpaths)
-      const parts = imp.split('/');
       if (imp.startsWith('@')) {
         // Scoped package like @vitejs/plugin-react
         return true;

--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -165,12 +165,13 @@ export async function POST(request: NextRequest) {
           console.log('[generate-ai-code-stream] Has fileCache:', !!global.sandboxState?.fileCache);
           console.log('[generate-ai-code-stream] Has manifest:', !!global.sandboxState?.fileCache?.manifest);
           
-          const manifest: FileManifest | undefined = global.sandboxState?.fileCache?.manifest;
-          
-          if (manifest) {
+          const fileCache = global.sandboxState?.fileCache;
+          const manifest: FileManifest | undefined = fileCache?.manifest;
+
+          if (fileCache && manifest) {
             await sendProgress({ type: 'status', message: '🔍 Creating search plan...' });
-            
-            const fileContents = global.sandboxState.fileCache.files;
+
+            const fileContents = fileCache.files;
             console.log('[generate-ai-code-stream] Files available for search:', Object.keys(fileContents).length);
             
             // STEP 1: Get search plan from AI
@@ -221,8 +222,7 @@ export async function POST(request: NextRequest) {
                     
                     // Create surgical edit context with exact location
                     const normalizedPath = target.filePath.replace('/home/user/app/', '');
-                    const fileContent = fileContents[normalizedPath]?.content || '';
-                    
+
                     // Build enhanced context with search results
                     enhancedSystemPrompt = `
 ${formatSearchResultsForAI(searchExecution.results)}
@@ -331,7 +331,7 @@ User request: "${prompt}"`;
                         
                         // For now, fall back to keyword search since we don't have file contents for search execution
                         // This path happens when no manifest was initially available
-                        let targetFiles = [];
+                        let targetFiles: string[] = [];
                         if (!searchPlan || searchPlan.searchTerms.length === 0) {
                           console.warn('[generate-ai-code-stream] No target files after fetch, searching for relevant files');
                           
@@ -951,51 +951,54 @@ CRITICAL: When files are provided in the context:
                       sandboxId: context?.sandboxId || 'unknown'
                     };
                   }
-                  
-                  // Store files in cache
-                  for (const [path, content] of Object.entries(filesData.files)) {
-                    const normalizedPath = path.replace('/home/user/app/', '');
-                    global.sandboxState.fileCache.files[normalizedPath] = {
-                      content: content as string,
-                      lastModified: Date.now()
-                    };
-                  }
-                  
-                  if (filesData.manifest) {
-                    global.sandboxState.fileCache.manifest = filesData.manifest;
-                    
-                    // Now try to analyze edit intent with the fetched manifest
-                    if (!editContext) {
-                      console.log('[generate-ai-code-stream] Analyzing edit intent with fetched manifest');
-                      try {
-                        const intentResponse = await fetch(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/analyze-edit-intent`, {
-                          method: 'POST',
-                          headers: { 'Content-Type': 'application/json' },
-                          body: JSON.stringify({ prompt, manifest: filesData.manifest, model })
-                        });
-                        
-                        if (intentResponse.ok) {
-                          const { searchPlan } = await intentResponse.json();
-                          console.log('[generate-ai-code-stream] Search plan received:', searchPlan);
-                          
-                          // Create edit context from AI analysis
-                          // Note: We can't execute search here without file contents, so fall back to keyword method
-                          const fileContext = selectFilesForEdit(prompt, filesData.manifest);
-                          editContext = fileContext;
-                          enhancedSystemPrompt = fileContext.systemPrompt;
-                          
-                          console.log('[generate-ai-code-stream] Edit context created with', editContext.primaryFiles.length, 'primary files');
+
+                  const cache = global.sandboxState.fileCache;
+                  if (cache) {
+                    // Store files in cache
+                    for (const [path, content] of Object.entries(filesData.files)) {
+                      const normalizedPath = path.replace('/home/user/app/', '');
+                      cache.files[normalizedPath] = {
+                        content: content as string,
+                        lastModified: Date.now()
+                      };
+                    }
+
+                    if (filesData.manifest) {
+                      cache.manifest = filesData.manifest;
+
+                      // Now try to analyze edit intent with the fetched manifest
+                      if (!editContext) {
+                        console.log('[generate-ai-code-stream] Analyzing edit intent with fetched manifest');
+                        try {
+                          const intentResponse = await fetch(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/analyze-edit-intent`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ prompt, manifest: filesData.manifest, model })
+                          });
+
+                          if (intentResponse.ok) {
+                            const { searchPlan } = await intentResponse.json();
+                            console.log('[generate-ai-code-stream] Search plan received:', searchPlan);
+
+                            // Create edit context from AI analysis
+                            // Note: We can't execute search here without file contents, so fall back to keyword method
+                            const fileContext = selectFilesForEdit(prompt, filesData.manifest);
+                            editContext = fileContext;
+                            enhancedSystemPrompt = fileContext.systemPrompt;
+
+                            console.log('[generate-ai-code-stream] Edit context created with', editContext.primaryFiles.length, 'primary files');
+                          }
+                        } catch (error) {
+                          console.error('[generate-ai-code-stream] Failed to analyze edit intent:', error);
                         }
-                      } catch (error) {
-                        console.error('[generate-ai-code-stream] Failed to analyze edit intent:', error);
                       }
                     }
+
+                    // Update variables
+                    backendFiles = cache.files;
+                    hasBackendFiles = Object.keys(backendFiles).length > 0;
+                    console.log('[generate-ai-code-stream] Updated backend cache with fetched files');
                   }
-                  
-                  // Update variables
-                  backendFiles = global.sandboxState.fileCache.files;
-                  hasBackendFiles = Object.keys(backendFiles).length > 0;
-                  console.log('[generate-ai-code-stream] Updated backend cache with fetched files');
                 }
               }
             } catch (error) {

--- a/app/api/get-sandbox-files/route.ts
+++ b/app/api/get-sandbox-files/route.ts
@@ -126,8 +126,9 @@ print(json.dumps(result))
     fileManifest.routes = extractRoutes(fileManifest.files);
     
     // Update global file cache with manifest
-    if (global.sandboxState?.fileCache) {
-      global.sandboxState.fileCache.manifest = fileManifest;
+    const cache = global.sandboxState?.fileCache;
+    if (cache) {
+      cache.manifest = fileManifest;
     }
 
     return NextResponse.json({


### PR DESCRIPTION
## Summary
- use the `google` AI provider and set `aiModel` to `LanguageModel` in analyze-edit-intent route
- guard `global.sandboxState.fileCache` in generate-ai-code-stream and other routes to avoid null access
- remove unused variables across API routes to reduce TypeScript warnings
- explicitly type fallback `targetFiles` list in generate-ai-code-stream route to resolve implicit `any[]` error

## Testing
- `npm run test:all` *(fails: Cannot find module '/workspace/open-lovable/tests/e2b-integration.test.js')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'missingImports' does not exist on type in app/page.tsx)*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689d88c9b94883248c16f1c92aa84d7c